### PR TITLE
Added nohup back to startup scripts

### DIFF
--- a/launch-a-1.sh
+++ b/launch-a-1.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &

--- a/launch-a-2.sh
+++ b/launch-a-2.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &

--- a/launch-a-3.sh
+++ b/launch-a-3.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &

--- a/launch-b-1.sh
+++ b/launch-b-1.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &

--- a/launch-b-2.sh
+++ b/launch-b-2.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &

--- a/launch-b-3.sh
+++ b/launch-b-3.sh
@@ -2,8 +2,8 @@
 
 # Form Consul Cluster
 sudo killall consul
-sudo consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
 
 # Form Nomad Cluster
 sudo killall nomad
-sudo nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &


### PR DESCRIPTION
- This was originally in the startup scripts but was removed on the
previous [PR](https://github.com/discoposse/nomad-vagrant-lab/pull/4).
- Adding this back will keep the logging from Nomad/Consul to stdout
which will interfere with running commands from the CLI on each node.
- Resolves https://github.com/discoposse/nomad-vagrant-lab/issues/5