### PR TITLE
Fixes Vancouver Sites for Consul/Nomad

### DIFF
--- a/consul-config/consul-server-west.hcl
+++ b/consul-config/consul-server-west.hcl
@@ -5,5 +5,5 @@ bootstrap_expect = 3
 advertise_addr   = "{{ GetInterfaceIP `eth1` }}"
 client_addr      = "0.0.0.0"
 ui               = true
-datacenter       = "toronto"
+datacenter       = "vancouver"
 retry_join       = ["172.16.1.201", "172.16.1.202", "172.16.1.203"]

--- a/nomad-config/nomad-server-west.hcl
+++ b/nomad-config/nomad-server-west.hcl
@@ -6,7 +6,7 @@ server {
   job_gc_threshold = "2m"
 }
 
-datacenter = "toronto"
+datacenter = "vancouver"
 
 region = "west"
 


### PR DESCRIPTION
- One of the previous commits mistakingly changed the Vancouver site to
also be Toronto. This causes issues on the representation of the site
obviously.
- This fixes the Vancouver site issue.
- Resolves https://github.com/discoposse/nomad-vagrant-lab/issues/8