### PR TITLE
Optimizes Launch Scripts

### DIFF
--- a/launch-a-1.sh
+++ b/launch-a-1.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-east.hcl /etc/consul.d/consul-server-east.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-east.hcl /etc/nomad.d/nomad-server-east.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &>$HOME/nomad.log &

--- a/launch-a-2.sh
+++ b/launch-a-2.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-east.hcl /etc/consul.d/consul-server-east.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-east.hcl /etc/nomad.d/nomad-server-east.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &>$HOME/nomad.log &

--- a/launch-a-3.sh
+++ b/launch-a-3.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-east.hcl /etc/consul.d/consul-server-east.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-east.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-east.hcl /etc/nomad.d/nomad-server-east.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-east.hcl &>$HOME/nomad.log &

--- a/launch-b-1.sh
+++ b/launch-b-1.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-west.hcl /etc/consul.d/consul-server-west.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-west.hcl /etc/nomad.d/nomad-server-west.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &>$HOME/nomad.log &

--- a/launch-b-2.sh
+++ b/launch-b-2.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-west.hcl /etc/consul.d/consul-server-west.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-west.hcl /etc/nomad.d/nomad-server-west.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &>$HOME/nomad.log &

--- a/launch-b-3.sh
+++ b/launch-b-3.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+cd $HOME
+
 # Form Consul Cluster
-sudo killall consul
-sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &
+ps -C consul
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall consul
+fi
+sudo cp /vagrant/consul-config/consul-server-west.hcl /etc/consul.d/consul-server-west.hcl
+sudo nohup consul agent --config-file /etc/consul.d/consul-server-west.hcl &>$HOME/consul.log &
 
 # Form Nomad Cluster
-sudo killall nomad
-sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &
+ps -C nomad
+retval=$?
+if [ $retval -eq 0 ]; then
+  sudo killall nomad
+fi
+sudo cp /vagrant/nomad-config/nomad-server-west.hcl /etc/nomad.d/nomad-server-west.hcl
+sudo nohup nomad agent -config /etc/nomad.d/nomad-server-west.hcl &>$HOME/nomad.log &


### PR DESCRIPTION
- The launch scripts work fine except on subsequent executions. We begin
to experience errors, etc. which are less than optimal. We need to
ensure that we are only killing processes when they are actually
already running.
- This will allow for future potential of streamlining the spin up of
auto starting the services at Vagrant provisioning time.
- Resolves https://github.com/discoposse/nomad-vagrant-lab/issues/10